### PR TITLE
Allow configuring list of strict pod labels(#63)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ Features & Constraints
 * Log watcher accepts one or more log configuration agent.
 * Log watcher will skip ``pause`` containers.
 * Configuration agents provide the ability to dynamically attach tags/attributes/metadata to logs based on Kubernetes labels.
-* **Optionally** follow logs from containers running in pods with at least ``application`` and ``version`` metadata labels. (optional since 0.14)
+* **Optionally** follow logs from containers running in pods with a defined list of metadata labels. (optional since 0.14)
 * Sync new and stale containers.
 
 Usage
@@ -255,9 +255,9 @@ WATCHER_CONTAINERS_PATH
   Containers directory path mounted from the host (Default: ``/var/lib/docker/containers``)
 
 WATCHER_STRICT_LABELS
-  If set then only containers running in pods with ``application`` and ``version`` metadata labels will be considered for log watching. (Default is ``False``)
+  If set then only containers running in pods with the list of metadata labels will be considered for log watching. Value is a comma separated string of label names. (Default is ``''``)
 
-  If not set then kubernetes-log-watcher will set ``application_id`` from *pod name*; in order to provide consistent attributes to log configuration agents.
+  If no ``application`` label is set then kubernetes-log-watcher will set ``application_id`` from *pod name*; in order to provide consistent attributes to log configuration agents.
 
 WATCHER_AGENTS
    Comma separated string of required log configuration agents. (Required. Example: "scalyr,appdynamics")

--- a/kube_log_watcher/main.py
+++ b/kube_log_watcher/main.py
@@ -115,7 +115,7 @@ def get_container_image_parts(config: dict) -> Tuple[str]:
 
 def sync_containers_log_agents(
         agents: list, watched_containers: list, containers: list, containers_path: str, cluster_id: str,
-        kube_url=None, strict_labels=[]) -> list:
+        kube_url=None, strict_labels=None) -> list:
     """
     Sync containers log configs using supplied agents.
 
@@ -234,14 +234,7 @@ def get_new_containers_log_targets(
             kwargs['node_name'] = CLUSTER_NODE_NAME
             kwargs['pod_annotations'] = pod_annotations
 
-            pod_strict_labels = {}
-
-            for label in strict_labels:
-                value = pod_labels.get(label)
-                if value:
-                    pod_strict_labels[label] = value
-
-            if set(strict_labels) - set(pod_strict_labels.keys()):
+            if set(strict_labels) - set(pod_labels.keys()):
                 logger.warning(
                     ('Labels "{}" are required for container({}: {}) in pod({}) '
                      '... Skipping!').format(','.join(strict_labels), container_name, container['id'], pod_name))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -216,7 +216,8 @@ def test_get_new_containers_log_targets(monkeypatch, fx_containers_sync):
     monkeypatch.setattr('kube_log_watcher.kube.get_pod', get_pod)
     monkeypatch.setattr('kube_log_watcher.main.CLUSTER_NODE_NAME', 'node-1')
 
-    targets = get_new_containers_log_targets(containers, CONTAINERS_PATH, CLUSTER_ID, strict_labels=True)
+    targets = get_new_containers_log_targets(containers, CONTAINERS_PATH, CLUSTER_ID,
+                                             strict_labels=['application', 'version'])
 
     assert targets == result
 
@@ -230,7 +231,8 @@ def test_get_new_containers_log_targets_not_found_pods(monkeypatch, fx_container
     monkeypatch.setattr('kube_log_watcher.kube.get_pod', get_pod)
     monkeypatch.setattr('kube_log_watcher.main.CLUSTER_NODE_NAME', 'node-1')
 
-    targets = get_new_containers_log_targets(containers, CONTAINERS_PATH, CLUSTER_ID, strict_labels=True)
+    targets = get_new_containers_log_targets(containers, CONTAINERS_PATH, CLUSTER_ID,
+                                             strict_labels=['application', 'version'])
 
     assert targets == []
 
@@ -245,7 +247,8 @@ def test_get_new_containers_log_targets_failuer(monkeypatch, fx_containers_sync)
     monkeypatch.setattr('kube_log_watcher.kube.is_pause_container', is_pause)
     monkeypatch.setattr('kube_log_watcher.main.CLUSTER_NODE_NAME', 'node-1')
 
-    targets = get_new_containers_log_targets(containers, CONTAINERS_PATH, CLUSTER_ID, strict_labels=True)
+    targets = get_new_containers_log_targets(containers, CONTAINERS_PATH, CLUSTER_ID,
+                                             strict_labels=['application', 'version'])
 
     assert targets == []
 
@@ -293,7 +296,7 @@ def test_load_agents(monkeypatch):
     agent1.assert_called_with(CLUSTER_ID, load_template)
 
 
-@pytest.mark.parametrize('strict', (True, False))
+@pytest.mark.parametrize('strict', (['application', 'version'], []))
 def test_watch(monkeypatch, strict):
     containers = [
         [{'id': 'cont-1'}, {'id': 'cont-2'}, {'id': 'cont-3'}],
@@ -348,7 +351,7 @@ def test_watch(monkeypatch, strict):
     sync_containers_log_agents_mock.assert_has_calls(calls, any_order=True)
 
 
-@pytest.mark.parametrize('strict', (True, False))
+@pytest.mark.parametrize('strict', (['application, version'], []))
 def test_watch_failure(monkeypatch, strict):
     sleep = MagicMock()
     sleep.return_value = None


### PR DESCRIPTION
This feature morphs the `WATCHER_STRICT_LABELS` configuration parameter from a boolean that enables restricting following pods labeled with `application` and `version` to a comma separated list of label names. This allows users to specify their own list of labels that need to be present to enable following of pods.