### PR TITLE
Fixes bug that strict labels are configured but not checked against

### DIFF
--- a/kube_log_watcher/main.py
+++ b/kube_log_watcher/main.py
@@ -143,7 +143,8 @@ def sync_containers_log_agents(
     :return: Existing container IDs and stale container IDs.
     :rtype: tuple
     """
-    containers_log_targets = get_new_containers_log_targets(containers, containers_path, cluster_id, kube_url=kube_url)
+    containers_log_targets = get_new_containers_log_targets(containers, containers_path, cluster_id, kube_url=kube_url,
+                                                            strict_labels=strict_labels)
 
     existing_container_ids = {c['id'] for c in containers_log_targets}
     stale_container_ids = get_stale_containers(watched_containers, existing_container_ids)


### PR DESCRIPTION
Hi @mohabusama ,

my bad I didn't test the change properly and didn't notice that the change doesn't work outside the tests.  The strict labels were never passed from the main function to the watcher.