### PR TITLE
Implement http timeout

### DIFF
--- a/.zappr.yaml
+++ b/.zappr.yaml
@@ -10,4 +10,4 @@ approvals:
   # Allow last committer / PR creator to approve as well.
   # This will probably become the default in zappr.
   ignore: none
-X-Zalando-Team: "eagleeye"
+X-Zalando-Team: "logging"

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -13,7 +13,6 @@ build_steps:
       libffi-dev \
       libssl-dev \
       tox
-    curl -sSL https://get.docker.com/ | sh
     pip3 install -r requirements.txt
     pip3 install -U flake8
 

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -26,9 +26,9 @@ build_steps:
     if [[ ${IS_PR_BUILD} != "true" ]]
     then
       RELEASE_VERSION=$(git describe --tags --always --dirty)
-      AGENT_IMAGE=registry-write.opensource.zalan.do/eagleeye/kubernetes-log-watcher:${RELEASE_VERSION}
+      AGENT_IMAGE=registry-write.opensource.zalan.do/logging/kubernetes-log-watcher:${RELEASE_VERSION}
     else
-      AGENT_IMAGE=registry-write.opensource.zalan.do/eagleeye/kubernetes-log-watcher-unstable:${CDP_BUILD_VERSION}
+      AGENT_IMAGE=registry-write.opensource.zalan.do/logging/kubernetes-log-watcher-unstable:${CDP_BUILD_VERSION}
     fi
     docker build --tag "$AGENT_IMAGE" .
     docker push "$AGENT_IMAGE"

--- a/kube_log_watcher/kube.py
+++ b/kube_log_watcher/kube.py
@@ -24,6 +24,19 @@ class PodNotFound(Exception):
     pass
 
 
+class TimedHTTPClient(pykube.HTTPClient):
+    def __init__(self, config, timeout=10):
+        self.timeout = timeout
+        super().__init__(config)
+
+    def get_kwargs(self, **kwargs):
+        """Override parent method to add timeout to all requests"""
+        kw = super().get_kwargs(**kwargs)
+        kw['timeout'] = self.timeout
+
+        return kw
+
+
 def update_ca_certificate():
     warnings.warn('update_ca_certificate is deprecated.')
     try:
@@ -36,7 +49,7 @@ def update_ca_certificate():
 
 def get_client():
     config = pykube.KubeConfig.from_service_account(DEFAULT_SERVICE_ACC)
-    client = pykube.HTTPClient(config)
+    client = TimedHTTPClient(config)
     client.session.trust_env = False
 
     return client

--- a/tests/test_kube.py
+++ b/tests/test_kube.py
@@ -42,7 +42,7 @@ def test_get_client(monkeypatch):
     kube_client = MagicMock()
 
     monkeypatch.setattr('pykube.KubeConfig', kube_config)
-    monkeypatch.setattr('pykube.HTTPClient', kube_client)
+    monkeypatch.setattr('kube_log_watcher.kube.TimedHTTPClient', kube_client)
 
     client = get_client()
 


### PR DESCRIPTION
When there are Kubernetes rolling updates it sometimes happens that connections get stuck and log messages won't get shipped to Scalyr.

For that we've come up with the solution that we'll wrap a timeout around pykube.