### PR TITLE
Change responsible Zalando team to 'logging'

### DIFF
--- a/.zappr.yaml
+++ b/.zappr.yaml
@@ -10,4 +10,4 @@ approvals:
   # Allow last committer / PR creator to approve as well.
   # This will probably become the default in zappr.
   ignore: none
-X-Zalando-Team: "eagleeye"
+X-Zalando-Team: "logging"


### PR DESCRIPTION
Ownership of the kubernetes-log-watcher was moved from `eagleeye` to `logging`.