### PR TITLE
Add server fields cluster_alias and cluster_environment to Scalyr Agent

### DIFF
--- a/kube_log_watcher/agents/scalyr.py
+++ b/kube_log_watcher/agents/scalyr.py
@@ -34,6 +34,8 @@ class ScalyrAgent(BaseWatcher):
         self.dest_path = os.environ.get('WATCHER_SCALYR_DEST_PATH')
         self.scalyr_server = os.environ.get('WATCHER_SCALYR_SERVER')
         self.parse_lines_json = os.environ.get('WATCHER_SCALYR_PARSE_LINES_JSON', False)
+        self.cluster_alias = os.environ.get('CLUSTER_ALIAS')
+        self.cluster_environment = os.environ.get('CLUSTER_ENVIRONMENT')
 
         if not all([self.api_key, self.dest_path]):
             raise RuntimeError('Scalyr watcher agent initialization failed. Env variables WATCHER_SCALYR_API_KEY and '
@@ -204,6 +206,8 @@ class ScalyrAgent(BaseWatcher):
         kwargs = {
             'scalyr_key': self.api_key,
             'cluster_id': self.cluster_id,
+            'cluster_alias': self.cluster_alias,
+            'cluster_environment': self.cluster_environment,
             'logs': self.logs,
             'monitor_journald': self.journald,
             'scalyr_server': self.scalyr_server,

--- a/kube_log_watcher/agents/scalyr.py
+++ b/kube_log_watcher/agents/scalyr.py
@@ -34,8 +34,8 @@ class ScalyrAgent(BaseWatcher):
         self.dest_path = os.environ.get('WATCHER_SCALYR_DEST_PATH')
         self.scalyr_server = os.environ.get('WATCHER_SCALYR_SERVER')
         self.parse_lines_json = os.environ.get('WATCHER_SCALYR_PARSE_LINES_JSON', False)
-        self.cluster_alias = os.environ.get('CLUSTER_ALIAS')
-        self.cluster_environment = os.environ.get('CLUSTER_ENVIRONMENT')
+        self.cluster_alias = os.environ.get('CLUSTER_ALIAS', 'none')
+        self.cluster_environment = os.environ.get('CLUSTER_ENVIRONMENT', 'production')
 
         if not all([self.api_key, self.dest_path]):
             raise RuntimeError('Scalyr watcher agent initialization failed. Env variables WATCHER_SCALYR_API_KEY and '

--- a/kube_log_watcher/templates/scalyr.json.jinja2
+++ b/kube_log_watcher/templates/scalyr.json.jinja2
@@ -5,7 +5,9 @@
     "implicit_agent_process_metrics_monitor": false,
 
     "server_attributes": {
-        "serverHost": "{{ cluster_id }}"
+        "serverHost": "{{ cluster_id }}",
+        "cluster_environment": "{{ cluster_environment }}",
+        "cluster_alias": "{{ cluster_alias }}"
     },
 
     {% if scalyr_server %}

--- a/tests/test_scalyr.py
+++ b/tests/test_scalyr.py
@@ -367,18 +367,33 @@ def test_remove_log_target(monkeypatch, env, exc):
     'kwargs,expected',
     (
         (
-            {'scalyr_key': SCALYR_KEY, 'cluster_id': CLUSTER_ID, 'monitor_journald': None, 'logs': []},
+            {
+                'scalyr_key': SCALYR_KEY,
+                'cluster_id': CLUSTER_ID,
+                'cluster_environment': 'testing',
+                'cluster_alias': 'cluster-alias',
+                'monitor_journald': None,
+                'logs': []
+            },
             {
                 'api_key': 'scalyr-key-123',
                 'implicit_metric_monitor': False,
                 'implicit_agent_process_metrics_monitor': False,
-                'server_attributes': {'serverHost': 'kube-cluster'},
+                'server_attributes': {
+                    'serverHost': 'kube-cluster',
+                    'cluster_environment': 'testing',
+                    'cluster_alias': 'cluster-alias'
+                    },
                 'logs': [], 'monitors': []
             },
         ),
         (
             {
-                'scalyr_key': SCALYR_KEY, 'cluster_id': CLUSTER_ID, 'logs': [],
+                'scalyr_key': SCALYR_KEY,
+                'cluster_id': CLUSTER_ID,
+                'cluster_environment': 'testing',
+                'cluster_alias': 'cluster-alias',
+                'logs': [],
                 'monitor_journald': {
                     'journal_path': None, 'attributes': {}, 'extra_fields': {}, 'write_rate': 10000,
                     'write_burst': 200000
@@ -388,7 +403,11 @@ def test_remove_log_target(monkeypatch, env, exc):
                 'api_key': 'scalyr-key-123',
                 'implicit_metric_monitor': False,
                 'implicit_agent_process_metrics_monitor': False,
-                'server_attributes': {'serverHost': 'kube-cluster'},
+                'server_attributes': {
+                    'serverHost': 'kube-cluster',
+                    'cluster_environment': 'testing',
+                    'cluster_alias': 'cluster-alias'
+                },
                 'logs': [],
                 'monitors': [
                     {
@@ -401,7 +420,10 @@ def test_remove_log_target(monkeypatch, env, exc):
         ),
         (
             {
-                'scalyr_key': SCALYR_KEY, 'cluster_id': CLUSTER_ID,
+                'scalyr_key': SCALYR_KEY,
+                'cluster_id': CLUSTER_ID,
+                'cluster_environment': 'testing',
+                'cluster_alias': 'cluster-alias',
                 'logs': [{'path': '/p1', 'attributes': {'a1': 'v1', 'parser': 'c-parser'}, 'copy_from_start': True}],
                 'monitor_journald': {
                     'journal_path': '/var/log/journal',
@@ -415,7 +437,11 @@ def test_remove_log_target(monkeypatch, env, exc):
                 'api_key': 'scalyr-key-123',
                 'implicit_metric_monitor': False,
                 'implicit_agent_process_metrics_monitor': False,
-                'server_attributes': {'serverHost': 'kube-cluster'},
+                'server_attributes': {
+                    'serverHost': 'kube-cluster',
+                    'cluster_environment': 'testing',
+                    'cluster_alias': 'cluster-alias'
+                    },
                 'logs': [{'attributes': {'a1': 'v1', 'parser': 'c-parser'}, 'path': '/p1', 'copy_from_start': True}],
                 'monitors': [
                     {
@@ -433,6 +459,8 @@ def test_remove_log_target(monkeypatch, env, exc):
             {
                 'scalyr_key': SCALYR_KEY,
                 'cluster_id': CLUSTER_ID,
+                'cluster_environment': 'testing',
+                'cluster_alias': 'cluster-alias',
                 'monitor_journald': None,
                 'logs': [
                     {
@@ -447,7 +475,10 @@ def test_remove_log_target(monkeypatch, env, exc):
                 'api_key': 'scalyr-key-123',
                 'implicit_metric_monitor': False,
                 'implicit_agent_process_metrics_monitor': False,
-                'server_attributes': {'serverHost': 'kube-cluster'},
+                'server_attributes': {
+                    'serverHost': 'kube-cluster',
+                    'cluster_environment': 'testing',
+                    'cluster_alias': 'cluster-alias'},
                 'monitors': [],
                 'logs': [
                     {
@@ -463,6 +494,8 @@ def test_remove_log_target(monkeypatch, env, exc):
             {
                 'scalyr_key': SCALYR_KEY,
                 'cluster_id': CLUSTER_ID,
+                'cluster_environment': 'testing',
+                'cluster_alias': 'cluster-alias',
                 'monitor_journald': None,
                 'logs': [
                     {
@@ -477,7 +510,10 @@ def test_remove_log_target(monkeypatch, env, exc):
                 'api_key': 'scalyr-key-123',
                 'implicit_metric_monitor': False,
                 'implicit_agent_process_metrics_monitor': False,
-                'server_attributes': {'serverHost': 'kube-cluster'},
+                'server_attributes': {
+                    'serverHost': 'kube-cluster',
+                    'cluster_environment': 'testing',
+                    'cluster_alias': 'cluster-alias'},
                 'monitors': [],
                 'logs': [
                     {
@@ -493,6 +529,8 @@ def test_remove_log_target(monkeypatch, env, exc):
                 {
                     'scalyr_key': SCALYR_KEY,
                     'cluster_id': CLUSTER_ID,
+                    'cluster_environment': 'testing',
+                    'cluster_alias': 'cluster-alias',
                     'parse_lines_json': True,
                     'monitor_journald': None,
                     'logs': [
@@ -508,7 +546,11 @@ def test_remove_log_target(monkeypatch, env, exc):
                     'api_key': 'scalyr-key-123',
                     'implicit_metric_monitor': False,
                     'implicit_agent_process_metrics_monitor': False,
-                    'server_attributes': {'serverHost': 'kube-cluster'},
+                    'server_attributes': {
+                        'serverHost': 'kube-cluster',
+                        'cluster_environment': 'testing',
+                        'cluster_alias': 'cluster-alias'
+                        },
                     'monitors': [],
                     'logs': [
                         {


### PR DESCRIPTION
In order to make it easier to find logs from a specific Kubernetes cluster without having to know the AWS account ID, the following fields should be added as server fields to the scalyr-agent configuration on Kubernetes:

* cluster_alias
* cluster_environment

Signed-off-by: Felix Mueller <felix.mueller@zalando.de>