### PR TITLE
Set `component` attribute for Scalyr

### DIFF
--- a/kube_log_watcher/agents/scalyr.py
+++ b/kube_log_watcher/agents/scalyr.py
@@ -163,6 +163,7 @@ class ScalyrAgent(BaseWatcher):
             'redaction_rules': get_redaction_rules(annotations, kwargs),
             'attributes': {
                 'application': kwargs['application_id'],
+                'component': kwargs['component'],
                 'environment': kwargs['environment'],
                 'version': kwargs['application_version'],
                 'cluster': kwargs['cluster_id'],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,7 @@ TARGET = {
     'id': 'container-1',
     'kwargs': {
         'application_id': 'app-1',
+        'component': 'main',
         'environment': 'test',
         'application_version': 'v1',
         'cluster_id': 'kube-cluster',


### PR DESCRIPTION
Add the `component` attribute to Scalyr log events. The value of the `component` attribute is taken from the `component` label. If no such label is set for the pod, the `component` attribute is set to the same value as the `application` attribute.