### PR TITLE
Fix `scalyr_sampling_rules` default value

### DIFF
--- a/kube_log_watcher/agents/scalyr.py
+++ b/kube_log_watcher/agents/scalyr.py
@@ -90,7 +90,7 @@ class ScalyrAgent(BaseWatcher):
     def __init__(self, configuration):
         cluster_id = configuration['cluster_id']
         self.scalyr_sampling_rules = self.parse_scalyr_sampling_rules(
-            configuration.get('scalyr_sampling_rules', []),
+            configuration.get('scalyr_sampling_rules') or [],
         )
         self.api_key = os.environ.get('WATCHER_SCALYR_API_KEY')
         self.dest_path = os.environ.get('WATCHER_SCALYR_DEST_PATH')

--- a/tests/test_scalyr.py
+++ b/tests/test_scalyr.py
@@ -203,6 +203,7 @@ def test_initialization_failure(monkeypatch, env, exists):
     with pytest.raises(RuntimeError):
         ScalyrAgent({
             'cluster_id': CLUSTER_ID,
+            'scalyr_sampling_rules': None,
         })
 
 


### PR DESCRIPTION
Handles when `scalyr_sampling_rules` is set to `None`