### PR TITLE
Use pod name as fallback for scalyr symlinks

### DIFF
--- a/kube_log_watcher/agents/scalyr.py
+++ b/kube_log_watcher/agents/scalyr.py
@@ -293,7 +293,7 @@ class ScalyrAgent(BaseWatcher):
     def _adjust_target_log_path(self, target):
         try:
             src_log_path = target['kwargs'].get('log_file_path')
-            application = target['kwargs'].get('application')
+            application = target['kwargs'].get('application') or target['kwargs'].get('pod_name') or 'none'
             version = target['kwargs'].get('version') or 'none'
             container_id = target['id']
 


### PR DESCRIPTION
With the previous change symlinks for containers without a application label looks like this:
`/mnt/scalyr-logs/e6b620b2bb589cf8a74722a22d320e2740af4fd810486113fd1070903c84eeda/-none.log`
Format is `{application}-{version}.log` 

This PR changes it to use the pod_name as fallback for the symlink