### PR TITLE
Parse lines as JSON

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -312,7 +312,7 @@ WATCHER_SCALYR_ENABLE_PROFILING
   If true, the agent will log performance profiling data about itself into a log file.
 
 WATCHER_SCALYR_PARSE_LINES_JSON
-  Parse lines lines on the client as JSON. Useful for raw docker logs. (Default: ``False``)
+  Comma-separated list of parsers expecting decoded JSON. Each item could also be defined as ``foo=bar`` to override defined parser ``foo`` with ``bar``. Useful for raw docker logs. (Default: ``""``)
 
 WATCHER_SCALYR_JOURNALD
   Scalyr should follow Journald logs. This is for node system processes log shipping (e.g. docker, kube) (Default: ``False``)

--- a/kube_log_watcher/templates/scalyr.json.jinja2
+++ b/kube_log_watcher/templates/scalyr.json.jinja2
@@ -15,6 +15,7 @@
     {% endif %}
     "implicit_metric_monitor": false,
     "implicit_agent_process_metrics_monitor": false,
+    "include_raw_timestamp_field": false,
     "server_attributes": {{ server_attributes | tojson }},
     {% if scalyr_server %}
     "scalyr_server": "{{ scalyr_server }}",
@@ -30,7 +31,7 @@
                 {% if log.redaction_rules %}
                 "redaction_rules": {{ log.redaction_rules | tojson }},
                 {% endif %}
-                {% if parse_lines_json %}
+                {% if log.parse_lines_as_json %}
                 "parse_lines_as_json": true,
                 {% endif %}
                 "copy_from_start": true,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -218,7 +218,6 @@ KWARGS = {
     'scalyr_key': SCALYR_KEY,
     'cluster_id': CLUSTER_ID,
     'monitor_journald': None,
-    'parse_lines_json': False,
     'enable_profiling': False,
     'logs': [
         {

--- a/tests/test_scalyr.py
+++ b/tests/test_scalyr.py
@@ -32,7 +32,7 @@ ENVS = (
         'WATCHER_SCALYR_JOURNALD_WRITE_BURST': '2'},
 )
 
-KWARGS_KEYS = ('scalyr_key', 'parse_lines_json', 'enable_profiling', 'cluster_id', 'logs', 'monitor_journald')
+KWARGS_KEYS = ('scalyr_key', 'enable_profiling', 'cluster_id', 'logs', 'monitor_journald')
 
 
 SCALYR_MONITOR_JOURNALD = copy.deepcopy(SCALYR_JOURNALD_DEFAULTS)
@@ -477,6 +477,7 @@ SERVER_ATTRIBUTES = {
                 "read_page_size": 131072,
                 'implicit_metric_monitor': False,
                 'implicit_agent_process_metrics_monitor': False,
+                "include_raw_timestamp_field": False,
                 'server_attributes': SERVER_ATTRIBUTES,
                 'logs': [], 'monitors': [], 'journald_logs': [],
             },
@@ -505,6 +506,7 @@ SERVER_ATTRIBUTES = {
                 "read_page_size": 131072,
                 'implicit_metric_monitor': False,
                 'implicit_agent_process_metrics_monitor': False,
+                "include_raw_timestamp_field": False,
                 'server_attributes': SERVER_ATTRIBUTES,
                 'logs': [],
                 'monitors': [
@@ -549,6 +551,7 @@ SERVER_ATTRIBUTES = {
                 "read_page_size": 131072,
                 'implicit_metric_monitor': False,
                 'implicit_agent_process_metrics_monitor': False,
+                "include_raw_timestamp_field": False,
                 'server_attributes': SERVER_ATTRIBUTES,
                 'logs': [
                     {
@@ -598,6 +601,7 @@ SERVER_ATTRIBUTES = {
                 "read_page_size": 131072,
                 'implicit_metric_monitor': False,
                 'implicit_agent_process_metrics_monitor': False,
+                "include_raw_timestamp_field": False,
                 'server_attributes': SERVER_ATTRIBUTES,
                 'monitors': [],
                 'logs': [
@@ -640,6 +644,7 @@ SERVER_ATTRIBUTES = {
                 "read_page_size": 131072,
                 'implicit_metric_monitor': False,
                 'implicit_agent_process_metrics_monitor': False,
+                "include_raw_timestamp_field": False,
                 'server_attributes': SERVER_ATTRIBUTES,
                 'monitors': [],
                 'logs': [
@@ -658,7 +663,6 @@ SERVER_ATTRIBUTES = {
             {
                 'scalyr_key': SCALYR_KEY,
                 'server_attributes': SERVER_ATTRIBUTES,
-                'parse_lines_json': True,
                 'enable_profiling': False,
                 'monitor_journald': None,
                 'logs': [
@@ -666,7 +670,8 @@ SERVER_ATTRIBUTES = {
                         'path': '/p1',
                         'attributes': {'a1': 'v1', 'parser': 'c-parser'},
                         'copy_from_start': True,
-                        'redaction_rules': {'match_expression': 'match-expression'}
+                        'redaction_rules': {'match_expression': 'match-expression'},
+                        'parse_lines_as_json': True,
                     }
                 ]
             },
@@ -684,6 +689,7 @@ SERVER_ATTRIBUTES = {
                 "read_page_size": 131072,
                 'implicit_metric_monitor': False,
                 'implicit_agent_process_metrics_monitor': False,
+                "include_raw_timestamp_field": False,
                 'server_attributes': SERVER_ATTRIBUTES,
                 'monitors': [],
                 'logs': [
@@ -703,7 +709,6 @@ SERVER_ATTRIBUTES = {
             {
                 'scalyr_key': SCALYR_KEY,
                 'server_attributes': SERVER_ATTRIBUTES,
-                'parse_lines_json': True,
                 'enable_profiling': True,
                 'monitor_journald': None,
                 'logs': [
@@ -718,7 +723,8 @@ SERVER_ATTRIBUTES = {
                             'container_id': CONTAINER_ID,
                         },
                         'copy_from_start': True,
-                        'redaction_rules': {'match_expression': 'match-expression'}
+                        'redaction_rules': {'match_expression': 'match-expression'},
+                        'parse_lines_as_json': True,
                     }
                 ],
             },
@@ -737,6 +743,7 @@ SERVER_ATTRIBUTES = {
                 "read_page_size": 131072,
                 'implicit_metric_monitor': False,
                 'implicit_agent_process_metrics_monitor': False,
+                "include_raw_timestamp_field": False,
                 'server_attributes': SERVER_ATTRIBUTES,
                 'monitors': [],
                 'logs': [


### PR DESCRIPTION
`WATCHER_SCALYR_PARSE_LINES_JSON` allows to define which parsers expects unwrapped logs.
It is also possible to override the parser to one that supports unwrapped logs.